### PR TITLE
Fix electron dev script

### DIFF
--- a/horary4/frontend/scripts/electron-dev.js
+++ b/horary4/frontend/scripts/electron-dev.js
@@ -75,7 +75,11 @@ class ElectronDevManager {
   async startViteServer() {
     this.log('Starting Vite development server...', 'vite');
     
-    this.viteProcess = spawn('npm', ['run', 'dev'], {
+    const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+    const frontendDir = path.join(__dirname, '..');
+
+    this.viteProcess = spawn(npmCmd, ['run', 'dev'], {
+      cwd: frontendDir,
       stdio: ['inherit', 'pipe', 'pipe'],
       env: { ...process.env, FORCE_COLOR: '1' }
     });


### PR DESCRIPTION
## Summary
- ensure electron dev spawns npm with Windows fallback and proper cwd

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run electron:dev` *(fails: Dev server not ready after 30 attempts)*

------
https://chatgpt.com/codex/tasks/task_e_684143d77fdc8324bb873d51266bd5ff