### PR TITLE
Fix spawn options for electron dev

### DIFF
--- a/horary4/frontend/scripts/electron-dev.js
+++ b/horary4/frontend/scripts/electron-dev.js
@@ -81,7 +81,8 @@ class ElectronDevManager {
     this.viteProcess = spawn(npmCmd, ['run', 'dev'], {
       cwd: frontendDir,
       stdio: ['inherit', 'pipe', 'pipe'],
-      env: { ...process.env, FORCE_COLOR: '1' }
+      env: { ...process.env, FORCE_COLOR: '1' },
+      shell: true
     });
 
     this.viteProcess.stdout.on('data', (data) => {
@@ -117,11 +118,12 @@ class ElectronDevManager {
     
     this.electronProcess = spawn(electronPath, ['.'], {
       stdio: ['inherit', 'pipe', 'pipe'],
-      env: { 
-        ...process.env, 
+      env: {
+        ...process.env,
         NODE_ENV: 'development',
         ELECTRON_ENABLE_LOGGING: '1'
-      }
+      },
+      shell: true
     });
 
     this.electronProcess.stdout.on('data', (data) => {


### PR DESCRIPTION
## Summary
- make Vite spawns use shell mode
- make Electron spawns use shell mode

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `timeout 5 npm run electron:dev`

------
https://chatgpt.com/codex/tasks/task_e_68414a340a508324b1935bbf81be4a85