### PR TITLE
Fix React entry point

### DIFF
--- a/horary4/frontend/index.html
+++ b/horary4/frontend/index.html
@@ -49,7 +49,7 @@
       </div>
     </div>
     
-    <script type="module" src="/src/main.jsx"></script>
+    <script type="module" src="/src/renderer.jsx"></script>
     
     <!-- Fallback for users with JavaScript disabled -->
     <noscript>

--- a/horary4/frontend/src/renderer.jsx
+++ b/horary4/frontend/src/renderer.jsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App.jsx';
+import './index.css';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);


### PR DESCRIPTION
## Summary
- fix index.html to load a React renderer instead of electron main script
- add `src/renderer.jsx` that mounts `<App/>` to the DOM

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_684151f9df3c83249245ce81ee8705b2